### PR TITLE
remove console.log statements in lib/highLevelConsumer.js

### DIFF
--- a/lib/highLevelConsumer.js
+++ b/lib/highLevelConsumer.js
@@ -193,14 +193,12 @@ HighLevelConsumer.prototype.connect = function () {
     });
 
     function register() {
-        console.log("Registered listeners");
         // Register for re-balances (broker or consumer changes)
         self.client.zk.on('consumersChanged', rebalance);
         self.client.zk.on('brokersChanged', rebalance);
     }
 
     function deregister() {
-        console.log("Deregistered listeners");
         // Register for re-balances (broker or consumer changes)
         self.client.zk.removeListener('consumersChanged', rebalance);
         self.client.zk.removeListener('brokersChanged', rebalance);
@@ -214,9 +212,7 @@ HighLevelConsumer.prototype.connect = function () {
         self.emit('error', err);
     });
 
-    this.client.on('close', function () {
-        console.log('close');
-    });
+    this.client.on('close', function () {});
 
     this.on('offsetOutOfRange', function (topic) {
         topic.maxNum = self.options.maxNumSegments;
@@ -254,12 +250,10 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
     // Do the rebalance.....
     var consumerPerTopicMap;
     var newTopicPayloads = [];
-    console.log("HighLevelConsumer %s is attempting to rebalance", self.id);
     async.series([
 
             // Stop fetching data and commit offsets
             function (callback) {
-                console.log("HighLevelConsumer %s stopping data read during rebalance", self.id);
                 self.stop(function () {
                     callback();
                 })
@@ -267,7 +261,6 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
 
             // Assemble the data
             function (callback) {
-                console.log("HighLevelConsumer %s assembling data for rebalance", self.id);
                 self.client.zk.getConsumersPerTopic(self.options.groupId, function (err, obj) {
                     if (err) {
                         callback(err);
@@ -281,7 +274,6 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
 
             // Release current partitions
             function (callback) {
-                console.log("HighLevelConsumer %s releasing current partitions during rebalance", self.id);
                 async.eachSeries(oldTopicPayloads, function (tp, cbb) {
                     if (tp['partition'] !== undefined) {
                         async.series([
@@ -330,7 +322,6 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
 
             // Reblannce
             function (callback) {
-                console.log("HighLevelConsumer %s determining the partitions to own during rebalance", self.id);
                 for (var topic in consumerPerTopicMap.consumerTopicMap[self.id]) {
                     var topicToAdd = consumerPerTopicMap.consumerTopicMap[self.id][topic];
                     var numberOfConsumers = consumerPerTopicMap.topicConsumerMap[topicToAdd].length;
@@ -361,7 +352,6 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
             // Update ZK with new ownership
             function (callback) {
                 if (newTopicPayloads.length) {
-                    console.log("HighLevelConsumer %s gaining ownership of partitions during rebalance", self.id);
                     async.eachSeries(newTopicPayloads, function (tp, cbb) {
                         if (tp['partition'] !== undefined) {
                             async.series([
@@ -402,7 +392,6 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
                     });
                 }
                 else {
-                    console.log("HighLevelConsumer %s has been assigned no partitions during rebalance", self.id);
                     callback();
                 }
             },
@@ -414,11 +403,9 @@ HighLevelConsumer.prototype.rebalanceAttempt = function (oldTopicPayloads, cb) {
             }],
         function (err) {
             if (err) {
-                console.log("HighLevelConsumer %s rebalance attempt failed", self.id);
                 cb(err);
             }
             else {
-                console.log("HighLevelConsumer %s rebalance attempt was successful", self.id);
                 cb();
             }
         });


### PR DESCRIPTION
I notices some console.logs left in the highLevelConsumer code. I just yanked them out as they are hinder adoption of kafka-node at my company.
